### PR TITLE
Related_item/list fix for CKAN 2.5 plus cosmetic changes on the home page

### DIFF
--- a/ckanext/open_alberta/fanstatic/css/main.css
+++ b/ckanext/open_alberta/fanstatic/css/main.css
@@ -2070,6 +2070,12 @@ body.pushed { right: 75%; overflow: hidden; }
 .alberta-theme header.site-header .nav-sub-section.opened { display: inline-block; }
 .alberta-theme header.site-header .local-nav-top { background-color: #f39b30; }
 .alberta-theme header.site-header .local-nav-top nav { display: block; width: 100%; white-space: nowrap; overflow-y: hidden; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+@media screen and (min-width: 480px) {
+    .alberta-theme header.site-header .local-nav-top nav ul li.navbar-right {
+        float: right !important;
+        margin-right: 0;
+    }
+}
 .alberta-theme header.site-header .local-nav-top nav ul li { margin-right: 24px; }
 .alberta-theme header.site-header .local-nav-top nav ul li.active { background-image: url("../img/subnav-active.png"); background-position: bottom center; background-repeat: no-repeat; }
 .alberta-theme header.site-header .local-nav-top nav ul li.active a { color: #333132; }

--- a/ckanext/open_alberta/templates/header.html
+++ b/ckanext/open_alberta/templates/header.html
@@ -127,6 +127,15 @@ then the "resources" section will be active and expanded on page load.
                                     <li id="nav-top-about" {% if level_one_section in subsections["about"] %}class="active"{% endif %}>
                                         <a href="/about">About</a>
                                     </li>
+                                    <li class="navbar-right">
+                                    {% if not (c.controller == 'user' and c.action == 'login') %}
+                                        {% if c.userobj %}
+                                            <a href="{{ h.url_for(controller='user', action='logout') }}"><i class="fa fa-unlock"></i></a>
+                                        {% else %}
+                                            <a href="{{ h.url_for(controller='user', action='login') }}"><i class="fa fa-lock"></i></a>
+                                        {% endif %}
+                                    {% endif %}
+                                    </li>
                                 </ul>
                             </nav>
                         </div>

--- a/ckanext/open_alberta/templates/home/snippets/middle.html
+++ b/ckanext/open_alberta/templates/home/snippets/middle.html
@@ -9,8 +9,10 @@
             <div class="row midcard">
                 <div class="col-sm-4 col-md-12 nopadding">
                     <div class="field-content query-count card-image" id="query-count-opendata">
-                        <a href='/opendata'><img src="img/od-pix-lake-louise-52756_1280-v0.03.jpg" class="img-responsive space-right-md"></a>
-                        <h4></h4>
+                        <a href='/opendata'>
+                            <img src="img/od-pix-lake-louise-52756_1280-v0.03.jpg" class="img-responsive space-right-md">
+                            <h4></h4>
+                        </a>
                     </div>
                 </div>
                 <div class="col-sm-8 col-md-12">
@@ -23,8 +25,10 @@
             <div class="row midcard">
                 <div class="col-sm-4 col-md-12 nopadding">
                     <div class="field-content query-count card-image" id="query-count-publications">
-                        <a href="/publications"><img src="img/pubs-trab-02_2161D_canmore_nordic_centre-v0.03.jpg" class="img-responsive space-right-md"></a>
-                        <h4></h4>
+                        <a href="/publications">
+                            <img src="img/pubs-trab-02_2161D_canmore_nordic_centre-v0.03.jpg" class="img-responsive space-right-md">
+                            <h4></h4>
+                        </a>
                     </div>
                 </div>
                 <div class="col-sm-8 col-md-12">
@@ -37,8 +41,10 @@
             <div class="row midcard">
                 <div class="col-sm-4 col-md-12 nopadding">
                     <div class="field-content card-image">
-                        <a target="_blank" href="http://www.qp.alberta.ca/"><img src="img/qptile-pix-edmonton-90597_1280-v0.03.jpg" class="img-responsive space-right-md"></a>
-                        <h4></h4>
+                        <a target="_blank" href="http://www.qp.alberta.ca/">
+                            <img src="img/qptile-pix-edmonton-90597_1280-v0.03.jpg" class="img-responsive space-right-md">
+                            <h4></h4>
+                        </a>
                     </div>           
                 </div>
                 <div class="col-sm-8 col-md-12">

--- a/ckanext/open_alberta/templates/package/edit_base.html
+++ b/ckanext/open_alberta/templates/package/edit_base.html
@@ -19,7 +19,7 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon('dataset_edit', _('Edit metadata'), id=pkg.name) }}
   {{ h.build_nav_icon('dataset_resources', _('Resources'), id=pkg.name) }}
-  {{ h.build_nav_icon('related_list', _('Related Items'), id=pkg.name) }}
+  {#  {{ h.build_nav_icon('related_list', _('Related Items'), id=pkg.name) }} #}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckanext/open_alberta/templates/package/read.html
+++ b/ckanext/open_alberta/templates/package/read.html
@@ -42,7 +42,8 @@
             <ul class="nav nav-tabs resource-tabs">
                 <li role="presentation" class="active" data-tab-group="data-results" data-tab-name="tab-summary"><a href="#summary">Summary</a></li>
                 <li role="presentation" data-tab-group="data-results" data-tab-name="tab-detailed"><a href="#detailed">Detailed Information</a></li>
-		{{ h.build_nav_icon('related_list', _('Related'), id=pkg.name) }}
+{# related_item/list will be removed from CKAN #}
+{#		{{ h.build_nav_icon('related_list', _('Related'), id=pkg.name) }}  #}
             </ul>
             <div id="result-summary" class="active tab-box tab-summary box" data-tab-group="data-results">
                 <div class="summary-section">


### PR DESCRIPTION
-   Moved H4 elements with item counts inside anchors on the home page.
-   Commented out references to related_item/list as this functionality has been removed in CKAN 2.5.
