### PR TITLE
CSS resource load order workaround

### DIFF
--- a/ckanext/open_alberta/sass/ab-opengov.scss
+++ b/ckanext/open_alberta/sass/ab-opengov.scss
@@ -25,7 +25,7 @@ $light-border-color: #a0a0a0;
     }
 }
 
-#alberta-ca {
+#alberta-ca.IDDP {
     overflow-x: hidden;
     background: #36424a;
     font-family: lato, sans-serif;

--- a/ckanext/open_alberta/templates/base.html
+++ b/ckanext/open_alberta/templates/base.html
@@ -18,4 +18,4 @@
     {% resource 'open_alberta/js/cookies.js' %}
     {{ super() }}
 {% endblock %}
-{% block bodytag %} id="alberta-ca" {{ super() }}{% endblock %}
+{% block bodytag %} id="alberta-ca" class="IDDP" {{ super() }}{% endblock %}


### PR DESCRIPTION
Added IDDP class to body and sass so open_alberta css selectors are more specific and take precedence.