### PR TITLE
Various fixes to templates/styling

### DIFF
--- a/ckanext/open_alberta/fanstatic/css/ab-opengov.css
+++ b/ckanext/open_alberta/fanstatic/css/ab-opengov.css
@@ -70,6 +70,8 @@
     }
 */
   /* Helpers */ }
+  #alberta-ca.IDDP table td {
+    border: 0px; }
   #alberta-ca.IDDP .form-horizontal .form-group {
     margin-left: 0;
     margin-right: 0; }

--- a/ckanext/open_alberta/fanstatic/css/ab-opengov.css
+++ b/ckanext/open_alberta/fanstatic/css/ab-opengov.css
@@ -79,7 +79,7 @@
     color: white;
     margin-left: 5px; }
   #alberta-ca.IDDP div[role=main] {
-    background: url(/img/homepage-bg.jpg) top left repeat-x; }
+    background: url(/img/homepage-bg.jpg) top left repeat; }
   #alberta-ca.IDDP .wrapper-main {
     padding: 0 15px; }
   #alberta-ca.IDDP .wrapper-package-read .page-header {

--- a/ckanext/open_alberta/sass/ab-opengov.scss
+++ b/ckanext/open_alberta/sass/ab-opengov.scss
@@ -34,6 +34,9 @@ $active-bg-color: #005072;
     font-size: 1.6em;
 
     // overrides
+    table td {
+        border: 0px;
+    }
     .form-horizontal .form-group {
         margin-left: 0;
         margin-right: 0;

--- a/ckanext/open_alberta/sass/ab-opengov.scss
+++ b/ckanext/open_alberta/sass/ab-opengov.scss
@@ -48,7 +48,7 @@ $active-bg-color: #005072;
     }
 
     div[role=main] {
-        background: url(/img/homepage-bg.jpg) top left repeat-x;
+        background: url(/img/homepage-bg.jpg) top left repeat;
     }
 
     .wrapper-main {

--- a/ckanext/open_alberta/templates/package/read.html
+++ b/ckanext/open_alberta/templates/package/read.html
@@ -53,11 +53,11 @@
   {% endfor %}
     </div>
     <hr>
-    <h2>Tags</h2>
+    <h2>Keywords</h2>
   {% if pkg.tags|length %}
       {% snippet "snippets/tag_list.html", tags=pkg.tags %}
   {% else %}
-    <p>No tags</p>
+    <p>No keywords</p>
   {% endif %}
     <hr>
     <h2>Dates</h2>

--- a/ckanext/open_alberta/templates/package/search.html
+++ b/ckanext/open_alberta/templates/package/search.html
@@ -36,25 +36,14 @@
 {% block page_primary_action %}
   {% if h.check_access('package_create') %}
     <div class="page_primary_action">
-    {% if dataset_type == "inventory" %}
-            <a class="btn btn-primary" href="/inventory/new"><i class="icon-plus-sign-alt"></i> Add Inventory</a>
-        {% endif %}
-	{% if dataset_type == "dataset" %}
-            <a class="btn btn-primary" href="/dataset/new"><i class="icon-plus-sign-alt"></i> Add Dataset</a>
-        {% endif %}
-        {% if dataset_type == "opendata" %}
-            <a class="btn btn-primary" href="/opendata/new"><i class="icon-plus-sign-alt"></i> Add OpenData</a>
-        {% endif %}
-        {% if dataset_type == "publications" %}
-            <a class="btn btn-primary" href="/publications/new"><i class="icon-plus-sign-alt"></i> Add Publication</a>
-        {% endif %}
-        {% if dataset_type == "documentation" %}
-            <a class="btn btn-primary" href="/documentation/new"><i class="icon-plus-sign-alt"></i> Add Documentation</a>
-        {% endif %}
+        <a class="btn btn-primary" href="/inventory/new"><i class="icon-plus-sign-alt"></i> Add Inventory</a>
+        <a class="btn btn-primary" href="/dataset/new"><i class="icon-plus-sign-alt"></i> Add Dataset</a>
+        <a class="btn btn-primary" href="/opendata/new"><i class="icon-plus-sign-alt"></i> Add OpenData</a>
+        <a class="btn btn-primary" href="/publications/new"><i class="icon-plus-sign-alt"></i> Add Publication</a>
+        <a class="btn btn-primary" href="/documentation/new"><i class="icon-plus-sign-alt"></i> Add Documentation</a>
     </div>
   {% endif %}
 {% endblock %}
-
 
 {% block form %}
   {% set facets = {

--- a/ckanext/open_alberta/templates/snippets/package_item.html
+++ b/ckanext/open_alberta/templates/snippets/package_item.html
@@ -39,7 +39,7 @@ Example:
 
     {% block heading_meta %}
       {% if package.private %}
-            <span class="dataset-private label"><i class="icon-lock"></i>{{ _('Private') }}</span>
+            <span class="dataset-private label label-default"><i class="icon-lock"></i>{{ _('Private') }}</span>
       {% endif %}
       {{ super() }}
     {% endblock %}

--- a/ckanext/open_alberta/templates/snippets/small_search.html
+++ b/ckanext/open_alberta/templates/snippets/small_search.html
@@ -2,8 +2,8 @@
 {% set placeholder = _('Enter search terms...') %}
 {% set input_class = input_class or 'search-giant' %}
 <form class="dataset-search {{ form_class }}" method="GET" data-module="select-switch" id="small_search">
-   <span class="control-group {{ input_class }}">
+   <span class="input-group {{ input_class }}">
         <input type="text" class="search_sm form-control" name="q" value="{{ c.q }}" autocomplete="off" placeholder="{{ placeholder }}" />
-    <a href="javascript:{}" class="search-submit" onclick="document.getElementById('small_search').submit();"><i class="fa fa-search"></i></a>
+    	<div class="input-group-btn"><a href="javascript:{}" class="btn search-submit" onclick="document.getElementById('small_search').submit();"><i class="fa fa-search"></i></a></div>
     </span>
 </form>


### PR DESCRIPTION
**Requested Changes**
- remove default styling creating a border around table cells
- add missing buttons under resources page
- rename "Tag" to "Keywords", requires further work on the filter page - seems to be part of CKAN core

**Tweaks**
- change background repeat to include y-axis.
- add default class to private label so that it is visible, under resource list.
- update small search form to use bootstrap classes