### PR TITLE
Re-added clone function to package read page.

### DIFF
--- a/ckanext/open_alberta/fanstatic/js/clone-ds.js
+++ b/ckanext/open_alberta/fanstatic/js/clone-ds.js
@@ -1,14 +1,27 @@
 $(function() {
+    $('#clone-btn').click(function() {
+        var icon = $('i', this);
+        if (icon.hasClass('icon-caret-down')) {
+            $('fieldset.clone').show()
+                               .find('input:eq(0)').focus();
+            icon.removeClass('icon-caret-down')
+                .addClass('icon-caret-up');
+        }
+        else {
+            $('fieldset.clone').hide();
+            icon.removeClass('icon-caret-up')
+                .addClass('icon-caret-down');
+        }
+    });
     /* This submits dataset clone request via Ajax.
      * It has to be done this way because the dataset view page has javascript tabs,
      * unlike vanilla CKAN.
      * */
-    $('#id-clone-ds-form button[type=submit]').click(function(e) {
-        console.log('clone clicked...');
-        var url = $('#id-clone-ds-form').attr('action');
+    $('#clone-form button[type=submit]').click(function(e) {
+        var url = $('#clone-form').attr('action');
         var titleInp = $('#field-title');
         var urlInp = $('#field-name');
-        $('#id-clone-ds-form .top-error-msg').text('').hide();
+        $('#clone-form .top-errors').text('').hide();
         titleInp.parent().removeClass('error').find('span.error-block').remove();
         urlInp.parent().removeClass('error').find('span.error-block').remove();
         $.post(url,
@@ -19,7 +32,7 @@ $(function() {
                     window.location.href = data.redirect_url;
                 else if (data.status == 'error') {
                     if (data.errorMessage) {
-                        $('#id-clone-ds-form .top-error-msg').text(data.errorMessage).show();
+                        $('#clone-form .top-errors').text(data.errorMessage).show();
                     }
                     else {
                         if (data.errors.title)

--- a/ckanext/open_alberta/sass/ab-opengov.scss
+++ b/ckanext/open_alberta/sass/ab-opengov.scss
@@ -13,7 +13,7 @@ $tag-bg-color: #a0a0a0;
 $active-color: #fff;
 $active-bg-color: #005072;
 
-/* Bootstrap v3.x folds the naviation at viewport width <= 768px, so desktop users see phone interface in many cases.
+/* Bootstrap v3.x folds the navigation at viewport width <= 768px, so desktop users see phone interface in many cases.
    This helps to override that to a custom value without rebuilding bootstrap. */
 @mixin screen-sm() {
     @media only screen and (max-width: $screen-xs) { 
@@ -650,6 +650,28 @@ $active-bg-color: #005072;
                     padding-left: 1em;
                 }
             }
+        }
+    }
+
+    .clone {
+        display: none;
+        border-radius: 5px;
+        padding: 10px 15px 0 15px;
+
+        .control-group {
+            max-width: 40em;
+
+            input {
+                width: 100%;
+            }
+        }
+
+        .slug-preview {
+            margin-top: 10px;
+        }
+
+        .form-actions {
+            margin: 0 auto 15px;
         }
     }
 

--- a/ckanext/open_alberta/templates/package/read.html
+++ b/ckanext/open_alberta/templates/package/read.html
@@ -20,7 +20,19 @@
 
 {% block content_primary_nav %}{% endblock %}
 
+{% set can_clone =  h.check_access('package_update', {'id':pkg.id }) %}
+{% block content_action %}
+  {{ super() }}
+  {% if can_clone %}
+    <a id="clone-btn" href="#" class="btn btn-primary">Clone <i class="icon-caret-down"></i></a>
+  {% endif %}
+{% endblock %}
+
 {% block primary_content_inner %}
+  {% if can_clone %}
+    {% snippet 'package/snippets/clone_form.html', pkg=pkg %}
+    {% resource 'open_alberta/js/clone-ds.js' %}
+  {% endif %}
     <h1>{{ pkg.title }}</h1>
   {% if notes_short|length < notes|length %}
     <div class="short">

--- a/ckanext/open_alberta/templates/package/snippets/clone_form.html
+++ b/ckanext/open_alberta/templates/package/snippets/clone_form.html
@@ -1,9 +1,10 @@
 {% import 'macros/form.html' as form %}
 
-<h2>{% block page_heading %}{{ _('Clone') }} {{ h.dataset_display_name(pkg) }}{% endblock %}</h2>
+<fieldset class="clone">
+  <legend>{% block page_heading %}{{ _('Clone') }} {{ h.dataset_display_name(pkg) }}{% endblock %}</legend>
 
-<form id="id-clone-ds-form" class="dataset-form form-horizontal" method="post" action="{{ h.url_for('clone', id=pkg.name) }}">
-    <div class="top-error-msg">Unexpected error message goes here...</div>
+<form id="clone-form" class="dataset-form form-horizontal" method="post" action="{{ h.url_for('clone', id=pkg.name) }}">
+    <div class="top-errors"></div>
 {% block package_basic_fields_title %}
   {{ form.input('title', id='field-title', label=_('Title'), placeholder=_('New Title'), 
                 attrs={'data-module': 'slug-preview-target'}, is_required=True) }}
@@ -23,3 +24,4 @@
         <button class="btn btn-primary" type="submit" name="save">{{ _('Clone') }}</button>
     </div>
 </form>
+</fieldset>


### PR DESCRIPTION
Note: the functionality requires ckanext.openalberta.clonable_ds_types configuration key in the config file.

ckanext.openalberta.clonable_ds_types = dataset,opendata,publication,inventory

The default is dataset,opendata, which is probably wrong

