### PR TITLE
Ported Home page redirect functionality from OGP

### DIFF
--- a/ckanext/open_alberta/fanstatic/js/admin.config.js
+++ b/ckanext/open_alberta/fanstatic/js/admin.config.js
@@ -1,0 +1,19 @@
+/*
+ * Show/hide Redirect URL input based on the value of homepage drop-down
+ */
+
+$(function() {
+    var hpstyle = $('#field-ckan-homepage-style');
+    if (hpstyle.val() != '301')
+        $('#field-ckan-abgov-301-url').parent().parent().hide();
+    else
+        $('#field-ckan-abgov-301-url').parent().parent().show();
+    hpstyle.on('change', function() {
+        var urlfld = $('#field-ckan-abgov-301-url');
+        if ($(this).val() == '301')
+            urlfld.parent().parent().show();
+        else {
+            urlfld.val('').parent().parent().hide();
+        }
+    });
+});

--- a/ckanext/open_alberta/templates/admin/config.html
+++ b/ckanext/open_alberta/templates/admin/config.html
@@ -6,3 +6,8 @@
         <input type="hidden" name="menu_items" value='{{ data.menu_items }}'>
     {% endif %}
 {% endblock %}
+
+{% block scripts %}
+{{ super() }}
+{% resource 'open_alberta/js/admin.config.js' %}
+{% endblock %}


### PR DESCRIPTION
Replaced CKAN admin system configuration page's home page layout drop-down with custom content.
There is an option now to set the home page URL to an external site. Choosing the option shows additional input with the URL.
CKAN home controller has been patched to detect the external home page setting and do the redirect.